### PR TITLE
Fix an UnboundLocalError in python/text_reporter

### DIFF
--- a/python/enolib/reporters/text_reporter.py
+++ b/python/enolib/reporters/text_reporter.py
@@ -15,7 +15,7 @@ class TextReporter(Reporter):
     gutter_header = context.messages.gutter_header.rjust(5)
     columns_header = f"  {gutter_header} | {context.messages.content_header}"
 
-    source = f"-- {source} --\n\n" if context.source is not None else ''
+    source = f"-- {context.source} --\n\n" if context.source is not None else ''
 
     self._gutter_width = len(gutter_header) + 3
     self._header = f"{source}{columns_header}\n"


### PR DESCRIPTION
This was the full text of the error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "__redacted__.py", line 21, in <module>
    main()
  File "__redacted__.py", line 18, in main
    load_records("records")
  File "__redacted__.py", line 15, in load_records
    load_record(f)
  File "__redacted__.py", line 11, in load_record
    return enolib.parse(f.read(), source=fpath)
  File "/home/clement/.local/lib/python3.6/site-packages/enolib/parse.py", line 5, in parse
    context = Context(input, **options)
  File "/home/clement/.local/lib/python3.6/site-packages/enolib/context.py", line 27, in __init__
    Analyzer(self).analyze()
  File "/home/clement/.local/lib/python3.6/site-packages/enolib/analyzer.py", line 195, in analyze
    raise Parsing.missing_fieldset_for_fieldset_entry(self._context, instruction)
  File "/home/clement/.local/lib/python3.6/site-packages/enolib/errors/parsing.py", line 60, in missing_fieldset_for_fieldset_entry
    context.reporter(context).report_line(entry).snippet(),
  File "/home/clement/.local/lib/python3.6/site-packages/enolib/reporters/text_reporter.py", line 18, in __init__
    source = f"-- {context.source} --\n\n" if context.source is not None else ''
UnboundLocalError: local variable 'source' referenced before assignment
```