### PR TITLE
In tests, compare deserialized structure instead of serialized yaml (#6)

### DIFF
--- a/python/tests/analyzer/test_analyzer.py
+++ b/python/tests/analyzer/test_analyzer.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -25,4 +25,4 @@ json
 def test_tokenizer():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/analyzer.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/analyzer.snap.yaml')

--- a/python/tests/analyzer/test_comments.py
+++ b/python/tests/analyzer/test_comments.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -11,4 +11,4 @@ input = """
 def test_comment_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/comment_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/comment_analysis.snap.yaml')

--- a/python/tests/analyzer/test_continuations.py
+++ b/python/tests/analyzer/test_continuations.py
@@ -1,5 +1,5 @@
 from tests.analyzer.util import analyze
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 
 input = """
 Field: Value
@@ -34,4 +34,4 @@ List with empty item:
 def test_continuations():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/continuations.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/continuations.snap.yaml')

--- a/python/tests/analyzer/test_copy_analysis.py
+++ b/python/tests/analyzer/test_copy_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -12,4 +12,4 @@ key    < template
 def test_escaped_copy_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/copy_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/copy_analysis.snap.yaml')

--- a/python/tests/analyzer/test_direct_line_continuation_analysis.py
+++ b/python/tests/analyzer/test_direct_line_continuation_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -14,4 +14,4 @@ field:
 def test_direct_line_continuation_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/direct_line_continuation_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/direct_line_continuation_analysis.snap.yaml')

--- a/python/tests/analyzer/test_empty_element_analysis.py
+++ b/python/tests/analyzer/test_empty_element_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -12,4 +12,4 @@ key:
 def test_empty_element_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/empty_element_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/empty_element_analysis.snap.yaml')

--- a/python/tests/analyzer/test_empty_line_analysis.py
+++ b/python/tests/analyzer/test_empty_line_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = ('\n'
@@ -13,4 +13,4 @@ input = ('\n'
 def test_empty_line_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/empty_line_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/empty_line_analysis.snap.yaml')

--- a/python/tests/analyzer/test_escaped_copy_analysis.py
+++ b/python/tests/analyzer/test_escaped_copy_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -14,4 +14,4 @@ template:
 def test_escaped_copy_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/escaped_copy_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/escaped_copy_analysis.snap.yaml')

--- a/python/tests/analyzer/test_escaped_fieldset_entry_analysis.py
+++ b/python/tests/analyzer/test_escaped_fieldset_entry_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -13,4 +13,4 @@ fieldset:
 def test_escaped_fieldset_entry_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/escaped_fieldset_entry_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/escaped_fieldset_entry_analysis.snap.yaml')

--- a/python/tests/analyzer/test_escaped_name_analysis.py
+++ b/python/tests/analyzer/test_escaped_name_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -16,4 +16,4 @@ input = """
 def test_escaped_key_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/escaped_key_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/escaped_key_analysis.snap.yaml')

--- a/python/tests/analyzer/test_escaped_section_analysis.py
+++ b/python/tests/analyzer/test_escaped_section_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -16,4 +16,4 @@ input = """
 def test_escaped_section_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/escaped_section_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/escaped_section_analysis.snap.yaml')

--- a/python/tests/analyzer/test_field_analysis.py
+++ b/python/tests/analyzer/test_field_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -12,4 +12,4 @@ key: value
 def test_field_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/field_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/field_analysis.snap.yaml')

--- a/python/tests/analyzer/test_fieldset_entry_analysis.py
+++ b/python/tests/analyzer/test_fieldset_entry_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -14,4 +14,4 @@ entry = value
 def test_field_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/fieldset_entry_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/fieldset_entry_analysis.snap.yaml')

--- a/python/tests/analyzer/test_list_item_analysis.py
+++ b/python/tests/analyzer/test_list_item_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -13,4 +13,4 @@ list:
 def test_list_item_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/list_item_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/list_item_analysis.snap.yaml')

--- a/python/tests/analyzer/test_multiline_field_analysis.py
+++ b/python/tests/analyzer/test_multiline_field_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -25,4 +25,4 @@ value
 def test_multiline_field_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/multiline_field_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/multiline_field_analysis.snap.yaml')

--- a/python/tests/analyzer/test_section_analysis.py
+++ b/python/tests/analyzer/test_section_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -12,4 +12,4 @@ input = """
 def test_field_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/section_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/section_analysis.snap.yaml')

--- a/python/tests/analyzer/test_spaced_line_continuation_analysis.py
+++ b/python/tests/analyzer/test_spaced_line_continuation_analysis.py
@@ -1,4 +1,4 @@
-from tests.util import snapshot
+from tests.util import match_object_snapshot
 from tests.analyzer.util import analyze
 
 input = """
@@ -14,4 +14,4 @@ field:
 def test_spaced_line_continuation_analysis():
     analysis = analyze(input)
 
-    assert analysis == snapshot(analysis, 'tests/analyzer/snapshots/spaced_line_continuation_analysis.snap.yaml')
+    assert match_object_snapshot(analysis, 'tests/analyzer/snapshots/spaced_line_continuation_analysis.snap.yaml')

--- a/python/tests/analyzer/util.py
+++ b/python/tests/analyzer/util.py
@@ -1,11 +1,10 @@
-import yaml
 from enolib.context import Context
 
 def analyze(input):
     context = Context(input)
 
-    return yaml.dump({
+    return {
         'document': context.document,
         'line_count': context.line_count,
         'meta': context.meta
-    })
+    }

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -1,5 +1,51 @@
 import json
+import yaml
 
+def cyclic_dict_safe_comparison(a, b):
+    def compare(a, b, visited_dicts_a, visited_dicts_b, path):
+        if isinstance(a, dict):
+            visited_dicts_a[id(a)] = path
+            visited_dicts_b[id(b)] = path
+
+            if id(a) in visited_dicts_a:
+                return id(b) in visited_dicts_b and visited_dicts_a[id(a)] == visited_dicts_b[id(b)]
+
+            return (isinstance(b, dict) and
+                a.keys() == b.keys() and
+                all([compare(a[k], b[k], visited_dicts_a, visited_dicts_b, path + [k]) for k in b.keys()]))
+
+        if isinstance(a, list):
+            return (isinstance(b, list) and
+                len(a) == len(b) and
+                all([compare(a[k], b[k], visited_dicts_a, visited_dicts_b, path + [k]) for k in range(len(b))]))
+
+        return a == b
+
+    return compare(a, b, {}, {}, [])
+
+def match_object_snapshot(content, filename):
+    try:
+        with open(filename, 'r') as file:
+            snapshot = yaml.full_load(file.read())
+
+        if cyclic_dict_safe_comparison(content, snapshot):
+            return True
+
+        comparison_filename = filename + '.actual'
+
+        with open(comparison_filename, 'w') as file:
+            file.write(yaml.dump(content))
+
+        print(f"1 snapshot comparison file written to {comparison_filename}")
+
+        return False
+    except FileNotFoundError:
+        with open(filename, 'w') as file:
+            file.write(yaml.dump(content))
+
+        print(f"1 snapshot written to {filename}")
+
+        return content
 
 def snapshot(content, filename):
     extension = filename.split('.')[-1]


### PR DESCRIPTION
Thanks!

It seems the problem was indeed that I was stuck to `pyyaml` 3.something (which, in spite of the large number jump, was just the previous release). I noticed because you are now using the function `full_load`, which is new.

So it was actually my fault, because you do specify `pyyaml==5.1` in the requirements -- but I'm using [nix](https://nixos.org/nix/), and not pip, so...

Up to you if you still want to move to compare the deserialized objects. Otherwise, feel free to ignore the PR :)