### PR TITLE
Introduce enum for InstructionType

### DIFF
--- a/python/enolib/constants.py
+++ b/python/enolib/constants.py
@@ -1,4 +1,6 @@
 # Added to 0-indexed indices in a few places
+from enum import Enum
+
 HUMAN_INDEXING = 1
 
 # Selection indices
@@ -6,29 +8,31 @@ BEGIN = 0
 END = 1
 
 # Instruction types
-COMMENT = 'Comment'
-CONTINUATION = 'Continuation'
-DOCUMENT = 'Document'
-EMPTY_ELEMENT = 'Empty Element'
-FIELD = 'Field'
-FIELDSET = 'Fieldset'
-FIELDSET_ENTRY = 'Fieldset Entry'
-LIST = 'List'
-LIST_ITEM = 'List Item'
-MULTILINE_FIELD_BEGIN = 'Multiline Field Begin'
-MULTILINE_FIELD_END = 'Multiline Field End'
-MULTILINE_FIELD_VALUE = 'Multiline Field Value'
-SECTION = 'Section'
-UNPARSED = 'Unparsed'
+class InstructionType(Enum):
+    COMMENT = 'Comment'
+    CONTINUATION = 'Continuation'
+    DOCUMENT = 'Document'
+    EMPTY_ELEMENT = 'Empty Element'
+    FIELD = 'Field'
+    FIELDSET = 'Fieldset'
+    FIELDSET_ENTRY = 'Fieldset Entry'
+    LIST = 'List'
+    LIST_ITEM = 'List Item'
+    MULTILINE_FIELD_BEGIN = 'Multiline Field Begin'
+    MULTILINE_FIELD_END = 'Multiline Field End'
+    MULTILINE_FIELD_VALUE = 'Multiline Field Value'
+    SECTION = 'Section'
+    UNPARSED = 'Unparsed'
 
-PRETTY_TYPES = {
-    DOCUMENT: 'document',
-    EMPTY_ELEMENT: 'empty_element',
-    FIELD: 'field',
-    FIELDSET: 'fieldset',
-    FIELDSET_ENTRY: 'fieldset_entry',
-    LIST: 'list',
-    LIST_ITEM: 'list_item',
-    MULTILINE_FIELD_BEGIN: 'field',
-    SECTION: 'section'
-}
+    def pretty(self):
+        return {
+            InstructionType.DOCUMENT: 'document',
+            InstructionType.EMPTY_ELEMENT: 'empty_element',
+            InstructionType.FIELD: 'field',
+            InstructionType.FIELDSET: 'fieldset',
+            InstructionType.FIELDSET_ENTRY: 'fieldset_entry',
+            InstructionType.LIST: 'list',
+            InstructionType.LIST_ITEM: 'list_item',
+            InstructionType.MULTILINE_FIELD_BEGIN: 'field',
+            InstructionType.SECTION: 'section'
+        }.get(self)

--- a/python/enolib/elements/element.py
+++ b/python/enolib/elements/element.py
@@ -1,4 +1,4 @@
-from ..constants import FIELDSET_ENTRY, LIST_ITEM
+from ..constants import InstructionType
 from ..errors.validation import Validation
 from . import fieldset_entry
 from . import list_item
@@ -12,7 +12,7 @@ class Element(SectionElement):
 
     def to_fieldset_entry(self):
         if not hasattr(self, '_fieldset_entry'):
-            if self._instruction['type'] != FIELDSET_ENTRY:
+            if self._instruction['type'] is not InstructionType.FIELDSET_ENTRY:
                 raise Validation.unexpected_element_type(self._context, None, self._instruction, 'expected_fieldset_entry')
 
             self._fieldset_entry = fieldset_entry.FieldsetEntry(self._context, self._instruction)
@@ -21,7 +21,7 @@ class Element(SectionElement):
 
     def to_list_item(self):
         if not hasattr(self, '_list_item'):
-            if self._instruction['type'] != LIST_ITEM:
+            if self._instruction['type'] is not InstructionType.LIST_ITEM:
                 raise Validation.unexpected_element_type(self._context, None, self._instruction, 'expected_list_item')
 
             self._list_item = list_item.ListItem(self._context, self._instruction)
@@ -29,7 +29,7 @@ class Element(SectionElement):
         return self._list_item
 
     def yields_fieldset_entry(self):
-        return self._instruction['type'] == FIELDSET_ENTRY
+        return self._instruction['type'] is InstructionType.FIELDSET_ENTRY
 
     def yields_list_item(self):
-        return self._instruction['type'] == LIST_ITEM
+        return self._instruction['type'] is InstructionType.LIST_ITEM

--- a/python/enolib/elements/element_base.py
+++ b/python/enolib/elements/element_base.py
@@ -1,5 +1,5 @@
 from ..errors.validation import Validation
-from ..constants import LIST_ITEM
+from ..constants import InstructionType
 
 class ElementBase:
     def __init__(self, context, instruction, parent=None):
@@ -27,7 +27,7 @@ class ElementBase:
             raise Validation.comment_error(self._context, message, self._instruction)
 
     def _key(self):
-        if self._instruction['type'] is LIST_ITEM:
+        if self._instruction['type'] is InstructionType.LIST_ITEM:
             return self._instruction['parent']['key']
 
         return self._instruction['key']

--- a/python/enolib/elements/section.py
+++ b/python/enolib/elements/section.py
@@ -7,15 +7,7 @@ from .missing import missing_fieldset
 from .missing import missing_list
 from .missing import missing_section
 from .missing import missing_section_element
-from ..constants import (
-    DOCUMENT,
-    EMPTY_ELEMENT,
-    FIELD,
-    FIELDSET,
-    LIST,
-    MULTILINE_FIELD_BEGIN,
-    SECTION
-)
+from ..constants import InstructionType
 
 class Section(ElementBase):
     def __init__(self, context, instruction, parent=None):
@@ -24,7 +16,7 @@ class Section(ElementBase):
         self._all_elements_required = parent._all_elements_required if parent else False
 
     def __repr__(self):
-        if self._instruction['type'] == DOCUMENT:
+        if self._instruction['type'] is InstructionType.DOCUMENT:
             return f"<class Section document elements={len(self._elements())}>"
 
         return f"<class Section key=\"{self._instruction['key']}\" elements={len(self._elements())}>"
@@ -91,7 +83,7 @@ class Section(ElementBase):
 
         element = elements[0]
 
-        if element._instruction['type'] != EMPTY_ELEMENT:
+        if element._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
             raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_empty')
 
         return element.to_empty()
@@ -123,9 +115,9 @@ class Section(ElementBase):
 
         element = elements[0]
 
-        if (element._instruction['type'] != FIELD and
-            element._instruction['type'] != MULTILINE_FIELD_BEGIN and
-            element._instruction['type'] != EMPTY_ELEMENT):
+        if (element._instruction['type'] is not  InstructionType.FIELD and
+            element._instruction['type'] is not InstructionType.MULTILINE_FIELD_BEGIN and
+            element._instruction['type'] is not InstructionType.EMPTY_ELEMENT):
             raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_field')
 
         return element.to_field()
@@ -157,7 +149,7 @@ class Section(ElementBase):
 
         element = elements[0]
 
-        if element._instruction['type'] != FIELDSET and element._instruction['type'] != EMPTY_ELEMENT:
+        if element._instruction['type'] is not InstructionType.FIELDSET and element._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
             raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_fieldset')
 
         return element.to_fieldset()
@@ -209,7 +201,7 @@ class Section(ElementBase):
 
         element = elements[0]
 
-        if element._instruction['type'] != LIST and element._instruction['type'] != EMPTY_ELEMENT:
+        if element._instruction['type'] is not InstructionType.LIST and element._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
             raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_list')
 
         return element.to_list()
@@ -253,7 +245,7 @@ class Section(ElementBase):
 
         element = elements[0]
 
-        if element._instruction['type'] != SECTION:
+        if element._instruction['type'] is not InstructionType.SECTION:
             raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_section')
 
         return element.to_section()
@@ -273,9 +265,9 @@ class Section(ElementBase):
         self._all_elements_required = required
 
         for element in self._elements():
-            if element._instruction['type'] == SECTION and element._yielded:
+            if element._instruction['type'] is InstructionType.SECTION and element._yielded:
                 element.to_section().all_elements_required(required)
-            elif element._instruction['type'] == FIELDSET and element._yielded:
+            elif element._instruction['type'] is InstructionType.FIELDSET and element._yielded:
                 element.to_fieldset().all_entries_required(required)
 
     def assert_all_touched(self, message=None, *, only=None, skip=None):
@@ -322,9 +314,9 @@ class Section(ElementBase):
             elements = elements_map[key] if key in elements_map else []
 
         def cast(element):
-            if (element._instruction['type'] != FIELD and
-                element._instruction['type'] != MULTILINE_FIELD_BEGIN and
-                element._instruction['type'] != EMPTY_ELEMENT):
+            if (element._instruction['type'] is not InstructionType.FIELD and
+                element._instruction['type'] is not InstructionType.MULTILINE_FIELD_BEGIN and
+                element._instruction['type'] is not InstructionType.EMPTY_ELEMENT):
                 raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_fields')
 
             return element.to_field()
@@ -344,7 +336,7 @@ class Section(ElementBase):
             elements = elements_map[key] if key in elements_map else []
 
         def cast(element):
-            if element._instruction['type'] != FIELDSET and element._instruction['type'] != EMPTY_ELEMENT:
+            if element._instruction['type'] is not InstructionType.FIELDSET and element._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
                 raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_fieldsets')
 
             return element.to_fieldset()
@@ -364,7 +356,7 @@ class Section(ElementBase):
             elements = elements_map[key] if key in elements_map else []
 
         def cast(element):
-            if element._instruction['type'] != LIST and element._instruction['type'] != EMPTY_ELEMENT:
+            if element._instruction['type'] is not InstructionType.LIST and element._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
                 raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_lists')
 
             return element.to_list()
@@ -390,7 +382,7 @@ class Section(ElementBase):
         return self._section(key, required=False)
 
     def parent(self):
-        if self._instruction['type'] == DOCUMENT:
+        if self._instruction['type'] is not InstructionType.DOCUMENT:
             return None
 
         return self._parent or Section(self._context, self._instruction['parent'])
@@ -426,7 +418,7 @@ class Section(ElementBase):
             elements = elements_map[key] if key in elements_map else []
 
         def cast(element):
-            if element._instruction['type'] != SECTION:
+            if element._instruction['type'] is not InstructionType.SECTION:
                 raise Validation.unexpected_element_type(self._context, key, element._instruction, 'expected_sections')
 
             return element.to_section()

--- a/python/enolib/elements/section_element.py
+++ b/python/enolib/elements/section_element.py
@@ -5,15 +5,7 @@ from . import fieldset
 from . import list as list_module  # don't globally override built-in list function
 from . import section
 from .element_base import ElementBase
-from ..constants import (
-    EMPTY_ELEMENT,
-    FIELD,
-    FIELDSET,
-    LIST,
-    MULTILINE_FIELD_BEGIN,
-    PRETTY_TYPES,
-    SECTION
-)
+from ..constants import InstructionType
 
 class SectionElement(ElementBase):
     # TODO: Revisit
@@ -42,64 +34,64 @@ class SectionElement(ElementBase):
     def to_empty(self):
         if not hasattr(self, '_empty'):
             if hasattr(self, '_yielded'):
-                raise TypeError(f"This element was already yielded as {PRETTY_TYPES[self._yielded]} and can't be yielded again as an empty.")
+                raise TypeError(f"This element was already yielded as {self._yielded.pretty()} and can't be yielded again as an empty.")
 
-            if self._instruction['type'] != EMPTY_ELEMENT:
+            if self._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
                 raise Validation.unexpected_element_type(self._context, None, self._instruction, 'expected_empty')
 
             self._empty = empty.Empty(self._context, self._instruction, self._parent)
-            self._yielded = EMPTY_ELEMENT
+            self._yielded = InstructionType.EMPTY_ELEMENT
 
         return self._empty
 
     def to_field(self):
         if not hasattr(self, '_field'):
             if hasattr(self, '_yielded'):
-                raise TypeError(f"This element was already yielded as {PRETTY_TYPES[self._yielded]} and can't be yielded again as a field.")
+                raise TypeError(f"This element was already yielded as {self._yielded.pretty()} and can't be yielded again as a field.")
 
-            if (self._instruction['type'] != FIELD and
-                self._instruction['type'] != MULTILINE_FIELD_BEGIN and
-                self._instruction['type'] != EMPTY_ELEMENT):
+            if (self._instruction['type'] is not InstructionType.FIELD and
+                self._instruction['type'] is not InstructionType.MULTILINE_FIELD_BEGIN and
+                self._instruction['type'] is not InstructionType.EMPTY_ELEMENT):
                 raise Validation.unexpected_element_type(self._context, None, self._instruction, 'expected_field')
 
             self._field = field.Field(self._context, self._instruction, self._parent)
-            self._yielded = FIELD
+            self._yielded = InstructionType.FIELD
 
         return self._field
 
     def to_fieldset(self):
         if not hasattr(self, '_fieldset'):
             if hasattr(self, '_yielded'):
-                raise TypeError(f"This element was already yielded as {PRETTY_TYPES[self._yielded]} and can't be yielded again as a fieldset.")
+                raise TypeError(f"This element was already yielded as {self._yielded.pretty()} and can't be yielded again as a fieldset.")
 
-            if self._instruction['type'] != FIELDSET and self._instruction['type'] != EMPTY_ELEMENT:
+            if self._instruction['type'] is not InstructionType.FIELDSET and self._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
                 raise Validation.unexpected_element_type(self._context, None, self._instruction, 'expected_fieldset')
 
             self._fieldset = fieldset.Fieldset(self._context, self._instruction, self._parent)
-            self._yielded = FIELDSET
+            self._yielded = InstructionType.FIELDSET
 
         return self._fieldset
 
     def to_list(self):
         if not hasattr(self, '_list'):
             if hasattr(self, '_yielded'):
-                raise TypeError(f"This element was already yielded as {PRETTY_TYPES[self._yielded]} and can't be yielded again as a list.")
+                raise TypeError(f"This element was already yielded as {self._yielded.pretty()} and can't be yielded again as a list.")
 
-            if self._instruction['type'] != LIST and self._instruction['type'] != EMPTY_ELEMENT:
+            if self._instruction['type'] is not InstructionType.LIST and self._instruction['type'] is not InstructionType.EMPTY_ELEMENT:
                 raise Validation.unexpected_element_type(self._context, None, self._instruction, 'expected_list')
 
             self._list = list_module.List(self._context, self._instruction, self._parent)
-            self._yielded = LIST
+            self._yielded =  InstructionType.LIST
 
         return self._list
 
     def to_section(self):
         if not hasattr(self, '_section'):
-            if self._instruction['type'] != SECTION:
+            if self._instruction['type'] is not InstructionType.SECTION:
                 raise Validation.unexpected_element_type(self._context, None, self._instruction, 'expected_section')
 
             self._section = section.Section(self._context, self._instruction, self._parent)
-            self._yielded = SECTION
+            self._yielded = InstructionType.SECTION
 
         return self._section
 
@@ -124,20 +116,20 @@ class SectionElement(ElementBase):
             self._section.touch()
 
     def yields_empty(self):
-        return self._instruction['type'] == EMPTY_ELEMENT
+        return self._instruction['type'] is InstructionType.EMPTY_ELEMENT
 
     def yields_field(self):
-        return (self._instruction['type'] == FIELD or
-                self._instruction['type'] == MULTILINE_FIELD_BEGIN or
-                self._instruction['type'] == EMPTY_ELEMENT)
+        return (self._instruction['type'] is InstructionType.FIELD or
+                self._instruction['type'] is InstructionType.MULTILINE_FIELD_BEGIN or
+                self._instruction['type'] is InstructionType.EMPTY_ELEMENT)
 
     def yields_fieldset(self):
-        return (self._instruction['type'] == FIELDSET or
-                self._instruction['type'] == EMPTY_ELEMENT)
+        return (self._instruction['type'] is InstructionType.FIELDSET or
+                self._instruction['type'] is InstructionType.EMPTY_ELEMENT)
 
     def yields_list(self):
-        return (self._instruction['type'] == LIST or
-                self._instruction['type'] == EMPTY_ELEMENT)
+        return (self._instruction['type'] is InstructionType.LIST or
+                self._instruction['type'] is InstructionType.EMPTY_ELEMENT)
 
     def yields_section(self):
-        return self._instruction['type'] == SECTION
+        return self._instruction['type'] is InstructionType.SECTION

--- a/python/enolib/errors/parsing.py
+++ b/python/enolib/errors/parsing.py
@@ -1,5 +1,5 @@
 import re
-from ..constants import BEGIN, DOCUMENT, END, HUMAN_INDEXING
+from ..constants import BEGIN, InstructionType, END, HUMAN_INDEXING
 from ..error_types import ParseError
 from .selections import cursor, select_line, select_template
 
@@ -81,7 +81,7 @@ class Parsing:
     def section_hierarchy_layer_skip(context, section, super_section):
         reporter = context.reporter(context).report_line(section)
 
-        if super_section['type'] != DOCUMENT:
+        if super_section['type'] is not InstructionType.DOCUMENT:
             reporter.indicate_line(super_section)
 
         return ParseError(

--- a/python/enolib/errors/selections.py
+++ b/python/enolib/errors/selections.py
@@ -1,14 +1,4 @@
-from ..constants import (
-    BEGIN,
-    END,
-    FIELD,
-    FIELDSET,
-    FIELDSET_ENTRY,
-    LIST,
-    LIST_ITEM,
-    MULTILINE_FIELD_BEGIN,
-    SECTION
-)
+from ..constants import BEGIN, END, InstructionType
 
 DOCUMENT_BEGIN = {
     'from': { 'column': 0, 'index': 0, 'line': 0 },
@@ -16,17 +6,17 @@ DOCUMENT_BEGIN = {
 }
 
 def last_in(element):
-    if ((element['type'] == FIELD or
-         element['type'] == LIST_ITEM or
-         element['type'] == FIELDSET_ENTRY) and 'continuations' in element):
+    if ((element['type'] is InstructionType.FIELD or
+         element['type'] is InstructionType.LIST_ITEM or
+         element['type'] is InstructionType.FIELDSET_ENTRY) and 'continuations' in element):
         return element['continuations'][-1]
-    elif element['type'] == LIST and 'items' in element:
+    elif element['type'] is InstructionType.LIST and 'items' in element:
         return last_in(element['items'][-1])
-    elif element['type'] == FIELDSET and 'entries' in element:
+    elif element['type'] is InstructionType.FIELDSET and 'entries' in element:
         return last_in(element['entries'][-1])
-    elif element['type'] == MULTILINE_FIELD_BEGIN:
+    elif element['type'] is InstructionType.MULTILINE_FIELD_BEGIN:
         return element['end']
-    elif element['type'] == SECTION and len(element['elements']) > 0:
+    elif element['type'] is InstructionType.SECTION and len(element['elements']) > 0:
         return last_in(element['elements'][-1])
     else:
         return element

--- a/python/enolib/lookup.py
+++ b/python/enolib/lookup.py
@@ -1,14 +1,6 @@
 from .context import Context
 from .elements.element import Element
-from .constants import (
-    BEGIN,
-    END,
-    FIELD,
-    FIELDSET,
-    LIST,
-    MULTILINE_FIELD_BEGIN,
-    SECTION
-)
+from .constants import BEGIN, END, InstructionType
 
 def check_multiline_field_by_line(field, line):
     if line < field['line'] or line > field['end']['line']:
@@ -164,24 +156,24 @@ def check_in_section_by_line(section, line):
         if element['line'] == line:
             return { 'element': element, 'instruction': element }
 
-        if element['type'] is FIELD:
+        if element['type'] is InstructionType.FIELD:
             match_in_field = check_field_by_line(element, line)
             if match_in_field:
                 return match_in_field
-        elif element['type'] is FIELDSET:
+        elif element['type'] is InstructionType.FIELDSET:
             match_in_fieldset = check_fieldset_by_line(element, line)
             if match_in_fieldset:
                 return match_in_fieldset
-        elif element['type'] is LIST:
+        elif element['type'] is InstructionType.LIST:
             match_in_list = check_list_by_line(element, line)
             if match_in_list:
                 return match_in_list
-        elif element['type'] is MULTILINE_FIELD_BEGIN:
+        elif element['type'] is InstructionType.MULTILINE_FIELD_BEGIN:
             if not 'template' in element:  # TODO: More elegant copy detection?
                 match_in_multiline_field = check_multiline_field_by_line(element, line)
                 if match_in_multiline_field:
                     return match_in_multiline_field
-        elif element['type'] is SECTION:
+        elif element['type'] is InstructionType.SECTION:
             return check_in_section_by_line(element, line)
 
         break
@@ -196,24 +188,24 @@ def check_in_section_by_index(section, index):
         if index <= element['ranges']['line'][END]:
             return { 'element': element, 'instruction': element }
 
-        if element['type'] is FIELD:
+        if element['type'] is InstructionType.FIELD:
             match_in_field = check_field_by_index(element, index)
             if match_in_field:
                 return match_in_field
-        elif element['type'] is FIELDSET:
+        elif element['type'] is InstructionType.FIELDSET:
             match_in_fieldset = check_fieldset_by_index(element, index)
             if match_in_fieldset:
                 return match_in_fieldset
-        elif element['type'] is LIST:
+        elif element['type'] is InstructionType.LIST:
             match_in_list = check_list_by_index(element, index)
             if match_in_list:
                 return match_in_list
-        elif element['type'] is MULTILINE_FIELD_BEGIN:
+        elif element['type'] is InstructionType.MULTILINE_FIELD_BEGIN:
             if not 'template' in element:  # TODO: More elegant copy detection?
                 match_in_multiline_field = check_multiline_field_by_index(element, index)
                 if match_in_multiline_field:
                     return match_in_multiline_field
-        elif element['type'] is SECTION:
+        elif element['type'] is InstructionType.SECTION:
             return check_in_section_by_index(element, index)
 
         break

--- a/python/enolib/reporters/reporter.py
+++ b/python/enolib/reporters/reporter.py
@@ -1,13 +1,4 @@
-from ..constants import (
-    DOCUMENT,
-    FIELD,
-    FIELDSET,
-    FIELDSET_ENTRY,
-    LIST,
-    LIST_ITEM,
-    MULTILINE_FIELD_BEGIN,
-    SECTION
-)
+from ..constants import InstructionType
 
 DISPLAY = 'Display Line'
 EMPHASIZE = 'Emphasize Line'
@@ -37,13 +28,13 @@ class Reporter:
 
                 self._index[element['line']] = element
 
-                if element['type'] == SECTION:
+                if element['type'] is InstructionType.SECTION:
                     traverse(element)
-                elif element['type'] == FIELD:
+                elif element['type'] is InstructionType.FIELD:
                     if 'continuations' in element:
                         for continuation in element['continuations']:
                             self._index[continuation['line']] = continuation
-                elif element['type'] == MULTILINE_FIELD_BEGIN:
+                elif element['type'] is InstructionType.MULTILINE_FIELD_BEGIN:
                     # Missing when reporting an unterminated multiline field
                     if 'end' in element:
                         self._index[element['end']['line']] = element['end']
@@ -52,7 +43,7 @@ class Reporter:
                         for line in element['lines']:
                             self._index[line['line']] = line
 
-                elif element['type'] == LIST:
+                elif element['type'] is InstructionType.LIST:
                     if 'items' in element:
                         for item in element['items']:
                             index_comments(item)
@@ -63,7 +54,7 @@ class Reporter:
                                 for continuation in item['continuations']:
                                     self._index[continuation['line']] = continuation
 
-                elif element['type'] == FIELDSET:
+                elif element['type'] is InstructionType.FIELDSET:
                     if 'entries' in element:
                         for entry in element['entries']:
                             index_comments(entry)
@@ -113,13 +104,13 @@ class Reporter:
         return scan_line
 
     def _tag_element(self, element, tag):
-        if element['type'] == FIELD or element['type'] == LIST_ITEM or element['type'] == FIELDSET_ENTRY:
+        if element['type'] is InstructionType.FIELD or element['type'] is InstructionType.LIST_ITEM or element['type'] is InstructionType.FIELDSET_ENTRY:
             return self._tag_continuations(element, tag)
-        elif element['type'] == LIST:
+        elif element['type'] is InstructionType.LIST:
             return self._tag_continuables(element, 'items', tag)
-        elif element['type'] == FIELDSET and 'entries' in element:
+        elif element['type'] is InstructionType.FIELDSET and 'entries' in element:
             return self._tag_continuables(element, 'entries', tag)
-        elif element['type'] == MULTILINE_FIELD_BEGIN:
+        elif element['type'] is InstructionType.MULTILINE_FIELD_BEGIN:
             if 'lines' in element:
                 for line in element['lines']:
                     self._snippet[line['line']] = tag
@@ -131,7 +122,7 @@ class Reporter:
                 return element['lines'][-1]['line'] + 1
             else:
                 return element['line'] + 1
-        elif element['type'] == SECTION:
+        elif element['type'] is InstructionType.SECTION:
             return self._tag_section(element, tag)
 
     def _tag_section(self, section, tag, recursive=True):
@@ -142,7 +133,7 @@ class Reporter:
                 self._snippet[scan_line] = INDICATE
                 scan_line += 1
 
-            if not recursive and element['type'] == SECTION:
+            if not recursive and element['type'] is InstructionType.SECTION:
                 break
 
             self._snippet[element['line']] = INDICATE
@@ -191,10 +182,10 @@ class Reporter:
         return self
 
     def report_missing_element(self, parent):
-        if parent['type'] != DOCUMENT:
+        if parent['type'] is not InstructionType.DOCUMENT:
             self._snippet[parent['line']] = INDICATE
 
-        if parent['type'] == SECTION:
+        if parent['type'] is InstructionType.SECTION:
             self._tag_section(parent, QUESTION, False)
         else:
             self._tag_element(parent, QUESTION)

--- a/python/enolib/reporters/terminal_reporter.py
+++ b/python/enolib/reporters/terminal_reporter.py
@@ -1,4 +1,4 @@
-from ..constants import BEGIN, COMMENT, END, HUMAN_INDEXING, UNPARSED
+from ..constants import BEGIN, END, HUMAN_INDEXING, InstructionType
 from .reporter import DISPLAY, EMPHASIZE, INDICATE, OMISSION, QUESTION, Reporter
 
 RESET = '\x1b[0m'
@@ -71,7 +71,7 @@ class TerminalReporter(Reporter):
 
         content = ''
         if instruction:
-            if instruction['type'] == COMMENT or instruction['type'] == UNPARSED:
+            if instruction['type'] is InstructionType.COMMENT or instruction['type'] is InstructionType.UNPARSED:
                 content = BRIGHT_BLACK + self._context.input[instruction['ranges']['line'][BEGIN]:instruction['ranges']['line'][END]] + RESET
             else:
                 content = self._context.input[instruction['ranges']['line'][BEGIN]:instruction['ranges']['line'][END]]

--- a/python/performance/benchmark.py
+++ b/python/performance/benchmark.py
@@ -1,5 +1,4 @@
 import json, time
-import pytest
 
 from datetime import datetime
 
@@ -23,7 +22,7 @@ reference = analysis['reference'] if 'reference' in analysis else None
 modifications = { '_evaluated': str(datetime.now()) }
 
 for name, content in SAMPLES.items():
-    before = time.clock()
+    before = time.perf_counter()
     seconds = 0
     iterations = 0
 
@@ -32,7 +31,7 @@ for name, content in SAMPLES.items():
             parse(content)
 
         iterations += 1000
-        seconds = time.clock() - before
+        seconds = time.perf_counter() - before
 
     ips = int(iterations / seconds)
     delta = ips - reference[name]['ips'] if reference else 0


### PR DESCRIPTION
While working on my serialization stuff, I thought it would be nice to convert all those constants to an enum - which is what this PR is :)
The tests are still passing, and the performance seems to be a bit improved:

Before
```
{
  "modifications": {
    "_evaluated": "2019-05-06 17:48:10.698904",
    "configuration": {
      "change": "~0 ips (same)",
      "ips": 8751
    },
    "content": {
      "change": "~0 ips (same)",
      "ips": 9562
    },
    "hierarchy": {
      "change": "~0 ips (same)",
      "ips": 8467
    },
    "invoice": {
      "change": "~0 ips (same)",
      "ips": 5030
    },
    "journey": {
      "change": "~0 ips (same)",
      "ips": 4085
    },
    "post": {
      "change": "~0 ips (same)",
      "ips": 20803
    }
  }
}
```

After:
```
{
  "modifications": {
    "_evaluated": "2019-05-06 17:49:25.508010",
    "configuration": {
      "change": "~0 ips (same)",
      "ips": 7890
    },
    "content": {
      "change": "~0 ips (same)",
      "ips": 9037
    },
    "hierarchy": {
      "change": "~0 ips (same)",
      "ips": 8370
    },
    "invoice": {
      "change": "~0 ips (same)",
      "ips": 4852
    },
    "journey": {
      "change": "~0 ips (same)",
      "ips": 4098
    },
    "post": {
      "change": "~0 ips (same)",
      "ips": 20350
    }
  }
}
```